### PR TITLE
ci: group dependabot updates by semver level and skip npm majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,16 @@ updates:
       - 'derogab'
     labels:
       - 'dependencies'
+    groups:
+      github-actions-major:
+        update-types:
+          - 'major'
+      github-actions-minor:
+        update-types:
+          - 'minor'
+      github-actions-patch:
+        update-types:
+          - 'patch'
 
   # Maintain dependencies for NPM
   - package-ecosystem: 'npm'
@@ -25,3 +35,13 @@ updates:
       - 'derogab'
     labels:
       - 'dependencies'
+    groups:
+      npm-minor:
+        update-types:
+          - 'minor'
+      npm-patch:
+        update-types:
+          - 'patch'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
## Summary
Configure Dependabot to open grouped PRs instead of one PR per dependency, and stop opening PRs for major version updates on npm so breaking upgrades are handled manually. GitHub Actions majors stay enabled (Actions are tagged with major-only versions, so ignoring them would disable all Actions updates) and arrive as a grouped PR.

Same change as derogab/poop-cleaner#78 and derogab/no-ip-updater#43, adapted for this repo's ecosystems.

## Changes
- Add `groups` to both ecosystems: minor bumps are combined into one PR and patch bumps into another, per ecosystem
- Add a `github-actions-major` group so Actions major bumps arrive as a single grouped PR instead of one PR each
- Add an `ignore` rule (`dependency-name: '*'` + `version-update:semver-major`) to npm so no major-version PRs are opened

## Test plan
- [x] YAML syntax validated locally
- [ ] After merge, wait for the next monthly Dependabot run and confirm PRs arrive grouped as `npm-minor` / `npm-patch` and `github-actions-*`, with no npm major bumps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Group Dependabot updates by semver level to cut PR noise, and ignore npm majors so breaking changes are handled manually. GitHub Actions majors remain enabled and arrive grouped.

- **Dependencies**
  - GitHub Actions: group major, minor, and patch updates into separate PRs.
  - npm: group minor and patch updates; ignore majors using `dependency-name: '*'` with `version-update:semver-major`.

<sup>Written for commit 61227786019a8c82c6c0351371a006095bd0ddfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/derogab/llm-proxy/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

